### PR TITLE
Remove (make safe) "single quote" character from date string (which brea...

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -673,7 +673,7 @@ function progress_bar($modules, $config, $events, $userid, $instance, $attempts,
                 '\''.$event['cmid'].'\', '.
                 '\''.addslashes($event['name']).'\', '.
                 '\''.get_string($config->{'action_'.$event['type'].$event['id']}, 'block_progress').'\', '.
-                '\''.userdate($event['expected'], $dateformat, $CFG->timezone).'\', '.
+                '\''.str_replace("'","",userdate($event['expected'], $dateformat, $CFG->timezone)).'\', '.
                 '\''.$instance.'\', '.
                 '\''.$userid.'\', '.
                 '\''.($attempted?'tick':'cross').'\''.


### PR DESCRIPTION
...ks JS)

When using Hebrew language in the course, Date strings inclue "Single Quote" chars just after the "Day" element in the Date format string. It breaks the JavaScript :-(

It might happen on other non English languages. so I am adding this safty check which remove the "Single Quote" char from the string.

Please code review, In case this hack needs to be applied elsewhere too.

Nadav :-)
