### PR TITLE
Add slashes (make safe) "single quote" character(s) on date string (whic...

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -717,7 +717,7 @@ function progress_bar($modules, $config, $events, $userid, $instance, $attempts,
                 '\''.$event['cmid'].'\', '.
                 '\''.addslashes($event['name']).'\', '.
                 '\''.get_string($action, 'block_progress').'\', '.
-                '\''.userdate($event['expected'], $dateformat, $CFG->timezone).'\', '.
+                '\''.addslashes(userdate($event['expected'], $dateformat, $CFG->timezone)).'\', '.
                 '\''.$instance.'\', '.
                 '\''.$userid.'\', '.
                 '\''.($attempted?'tick':'cross').'\''.


### PR DESCRIPTION
...h breaks JS)

When using Hebrew language in the course, Date strings include "Single Quote" chars just after the "Day" element in the Date format string. It breaks the JavaScript :-(

It might happen on other non English languages. so I am adding this safety check which "add slashes" to the "Single Quote" char in the string.

Please code review, In case this hack needs to be applied elsewhere too.

Nadav :-)
