### PR TITLE
Mk progress bar activity logo

### DIFF
--- a/lang/en/block_progress.php
+++ b/lang/en/block_progress.php
@@ -43,6 +43,7 @@ $string['imscp'] = 'IMS Content Package';
 $string['journal'] = 'Journal';
 $string['lesson'] = 'Lesson';
 $string['page'] = 'Page';
+$string['video'] = 'Video';
 $string['questionnaire'] = 'Questionnaire';
 $string['quiz'] = 'Quiz';
 $string['resource'] = 'File';
@@ -51,6 +52,7 @@ $string['scorm'] = 'SCORM';
 $string['turnitintool'] = 'Turnitin Tool';
 $string['url'] = 'URL';
 $string['wiki'] = 'Wiki';
+$string['ouwiki'] = 'OU Wiki';
 $string['workshop'] = 'Workshop';
 
 // Actions.

--- a/lib.php
+++ b/lib.php
@@ -1062,6 +1062,10 @@ function block_progress_bar($modules, $config, $events, $userid, $instance, $att
         $content .= HTML_WRITER::start_tag('div', $divoptions);
         $link = '/mod/'.$event['type'].'/view.php?id='.$event['cm']->id;
         $text = $OUTPUT->pix_icon('icon', '', $event['type'], array('class' => 'moduleIcon')).s($event['name']);
+        if(!empty($event['cm']->get_icon_url())){
+            $text = html_writer::empty_tag('img', array('src' => $event['cm']->get_icon_url(),
+                    'class' => 'moduleIcon', 'alt' => '', 'role' => 'presentation')).s($event['name']);
+        }
         if (!empty($event['cm']->available)) {
             $content .= $OUTPUT->action_link($link, $text);
         } else {

--- a/lib.php
+++ b/lib.php
@@ -441,6 +441,27 @@ function block_progress_monitorable_modules() {
             ),
             'defaultAction' => 'viewed'
         ),
+        'video' => array(
+            'actions' => array(
+                'viewed' => array (
+                    'logstore_legacy'     => "SELECT id
+                                                FROM {log}
+                                               WHERE course = :courseid
+                                                 AND module = 'video'
+                                                 AND action = 'view'
+                                                 AND cmid = :cmid
+                                                 AND userid = :userid",
+                    'sql_internal_reader' => "SELECT id
+                                                FROM {log}
+                                               WHERE courseid = :courseid
+                                                 AND component = 'mod_video'
+                                                 AND action = 'viewed'
+                                                 AND objectid = :eventid
+                                                 AND userid = :userid",
+                ),
+            ),
+            'defaultAction' => 'viewed'
+        ),
         'questionnaire' => array(
             'defaultTime' => 'closedate',
             'actions' => array(
@@ -552,6 +573,27 @@ function block_progress_monitorable_modules() {
                                                 FROM {log}
                                                WHERE courseid = :courseid
                                                  AND component = 'mod_wiki'
+                                                 AND action = 'viewed'
+                                                 AND objectid = :eventid
+                                                 AND userid = :userid",
+                ),
+            ),
+            'defaultAction' => 'viewed'
+        ),
+        'ouwiki' => array(
+            'actions' => array(
+                'viewed' => array (
+                    'logstore_legacy'     => "SELECT id
+                                                FROM {log}
+                                               WHERE course = :courseid
+                                                 AND module = 'ouwiki'
+                                                 AND action = 'view'
+                                                 AND cmid = :cmid
+                                                 AND userid = :userid",
+                    'sql_internal_reader' => "SELECT id
+                                                FROM {log}
+                                               WHERE courseid = :courseid
+                                                 AND component = 'mod_ouwiki'
                                                  AND action = 'viewed'
                                                  AND objectid = :eventid
                                                  AND userid = :userid",

--- a/lib.php
+++ b/lib.php
@@ -1061,11 +1061,13 @@ function block_progress_bar($modules, $config, $events, $userid, $instance, $att
                             'style' => 'display: none;');
         $content .= HTML_WRITER::start_tag('div', $divoptions);
         $link = '/mod/'.$event['type'].'/view.php?id='.$event['cm']->id;
-        $text = $OUTPUT->pix_icon('icon', '', $event['type'], array('class' => 'moduleIcon')).s($event['name']);
+        $text = '';
         $activity_icon = $event['cm']->get_icon_url();
         if(!empty($activity_icon)){
             $text = html_writer::empty_tag('img', array('src' => $activity_icon,
                     'class' => 'moduleIcon', 'alt' => '', 'role' => 'presentation')).s($event['name']);
+        }else{
+            $text = $OUTPUT->pix_icon('icon', '', $event['type'], array('class' => 'moduleIcon')).s($event['name']);
         }
         if (!empty($event['cm']->available)) {
             $content .= $OUTPUT->action_link($link, $text);

--- a/lib.php
+++ b/lib.php
@@ -1062,8 +1062,9 @@ function block_progress_bar($modules, $config, $events, $userid, $instance, $att
         $content .= HTML_WRITER::start_tag('div', $divoptions);
         $link = '/mod/'.$event['type'].'/view.php?id='.$event['cm']->id;
         $text = $OUTPUT->pix_icon('icon', '', $event['type'], array('class' => 'moduleIcon')).s($event['name']);
-        if(!empty($event['cm']->get_icon_url())){
-            $text = html_writer::empty_tag('img', array('src' => $event['cm']->get_icon_url(),
+        $activity_icon = $event['cm']->get_icon_url();
+        if(!empty($activity_icon)){
+            $text = html_writer::empty_tag('img', array('src' => $activity_icon,
                     'class' => 'moduleIcon', 'alt' => '', 'role' => 'presentation')).s($event['name']);
         }
         if (!empty($event['cm']->available)) {


### PR DESCRIPTION
When hovering over segments in the progress bar, the icons being displayed were that of the activities Resource Type and not that which is defined at the activity level. This resulted in a mismatch between the icon displayed next to the activity and that displayed in the progress bar (on hover).

We now check to see if it has a specific activity icon and if so display that instead of the generic resource icon