### PR TITLE
Add support for Digital Media e-Learning Module

### DIFF
--- a/lang/en/block_progress.php
+++ b/lang/en/block_progress.php
@@ -33,6 +33,7 @@ $string['certificate'] = 'Certificate';
 $string['chat'] = 'Chat';
 $string['choice'] = 'Choice';
 $string['data'] = 'Database';
+$string['dmelearn'] = 'Digital Media e-Learning';
 $string['equella'] = 'Equella';
 $string['feedback'] = 'Feedback';
 $string['flashcardtrainer'] = 'Flashcard trainer';

--- a/lib.php
+++ b/lib.php
@@ -270,6 +270,16 @@ function block_progress_monitorable_modules() {
             ),
             'defaultAction' => 'viewed'
         ),
+        'dmelearn' => array(
+            'actions' => array(
+                'finished'     => "SELECT id
+                                     FROM {dmelearn_entries}
+                                    WHERE dmelearn = :eventid
+                                      AND grade >= 100
+                                      AND userid = :userid"
+            ),
+            'defaultAction' => 'finished'
+        ),
         'equella' => array(
             'actions' => array(
                 'viewed' => array (


### PR DESCRIPTION
This is to add support for the [mod_dmelearn plugin](https://moodle.org/plugins/mod_dmelearn)
Moodle Activity as discussed with Mark W within the comments on the Progress Bar Moodle Plugin Directory page.