### PR TITLE
Correct icon class to correctly show svg icons

### DIFF
--- a/edit_form.php
+++ b/edit_form.php
@@ -321,7 +321,7 @@ class block_progress_edit_form extends block_edit_form {
 
                             // Icon, module type and name.
                             $modulename = get_string('pluginname', $moduleinfo->module);
-                            $icon = $OUTPUT->pix_icon('icon', $modulename, 'mod_'.$moduleinfo->module);
+                            $icon = $OUTPUT->pix_icon('icon', $modulename, 'mod_'.$moduleinfo->module, array('class' => 'iconlarge activityicon'));
                             $text = '&nbsp;'.$moduleinfo->label.':&nbsp;'.format_string($moduleinfo->instancename);
                             $attributes = array('class' => 'progressConfigModuleTitle');
                             $moduletitle = HTML_WRITER::tag('div', $icon.$text, $attributes);


### PR DESCRIPTION
Hi Michael!

If found that if the activity does not have the icon in png, the configuration form shows the svg in a very huge format. Adding this classes to the icon it takes the same size for all.

Cheers!