### PR TITLE
altered lib.php questionnaire - change in 3.3 column name from userna…

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -754,7 +754,7 @@ function block_progress_monitorable_modules() {
                 'finished'     => "SELECT id
                                      FROM {questionnaire_response}
                                     WHERE complete = 'y'
-                                      AND username = :userid
+                                      AND userid = :userid
                                       AND survey_id = :eventid",
             ),
             'defaultAction' => 'finished'


### PR DESCRIPTION
…me to userid

small fix as we got a db error when progress bar attempted the query with the 33 version of questionnaire - this is where it's mentioned https://github.com/PoetOS/moodle-mod_questionnaire/blob/784ee43ca0ebb8cac8bc5f75b2fc3eec0524b1db/db/upgrade.php#L577

hope ok - cheers
